### PR TITLE
Update CallbackStream.php

### DIFF
--- a/src/CallbackStream.php
+++ b/src/CallbackStream.php
@@ -40,12 +40,20 @@ class CallbackStream implements StreamableInterface
      */
     public function __toString()
     {
-        if ($this->called) {
-            return '';
-        }
+        ob_start();
+        $this->output();
+        return ob_get_clean();
+    }
+    
+    public function output() {
 
+        if ($this->called) {
+            return;
+        }
+        
         $this->called = true;
-        return call_user_func($this->callback);
+        call_user_func($this->callback);
+
     }
 
     /**
@@ -156,12 +164,9 @@ class CallbackStream implements StreamableInterface
      */
     public function read($length)
     {
-        if ($this->called) {
-            return false;
-        }
-
-        $this->called = true;
-        return call_user_func($this->callback);
+        ob_start();
+        $this->output();
+        return ob_get_clean();
     }
 
     /**
@@ -169,12 +174,9 @@ class CallbackStream implements StreamableInterface
      */
     public function getContents()
     {
-        if ($this->called) {
-            return '';
-        }
-
-        $this->called = true;
-        return call_user_func($this->callback);
+        ob_start();
+        $this->output();
+        return ob_get_clean();
     }
 
     /**


### PR DESCRIPTION
Just posting this as an example. This would be a more sane approach to dealing with output.

It adds a separate output() method that explicitly sends its content to the output buffer.
`getContents()` and `__toString()`  still behave exactly like they did before.

`read()` also, but I think your implementation of `read()` breaks the PSR-7 contract, because I don't think you're allowed to return _more_ than `$length`, according to the spec at least.

The way an implementor could do this, is by creating a new stream interface that has the `output()` method. This way the high-performance approach can be taken if it's available, but you can fall back to `getContent()` if not.
